### PR TITLE
Do not use third-party domain as placeholder link

### DIFF
--- a/tehtavat.md
+++ b/tehtavat.md
@@ -2654,7 +2654,7 @@ Toteuta sovelluksellesi esim. [Travis CI](https://travis-ci.org/):n avulla jatku
 
 ### 7.23 Kurssipalaute
 
-Anna kurssille palautetta osoitteessa <https://tba.fi>
+Anna kurssille palautetta osoitteessa *(osoite julkaistaan myöhemmin)*.
 
 ### Tehtävien palautus
 


### PR DESCRIPTION
Third-party sites can contain *anything*, and you never should use them
as "placeholders". Instead, just tell that URL will be published later.