### PR TITLE
Fixed ambiguous statement

### DIFF
--- a/osa1.md
+++ b/osa1.md
@@ -201,7 +201,7 @@ mutta JSX:ää kirjoittaessa tagi on pakko sulkea:
 
 ## Monta komponenttia
 
-Muutetaan sovellusta seuraavasti (yläreunan importit jätetään nyt ja jatkossa pois):
+Muutetaan sovellusta seuraavasti (yläreunan importit jätetään *esimerkeistä* nyt ja jatkossa pois):
 
 ```react
 const Hello = () => {


### PR DESCRIPTION
At least with the current version of create-react-app you can't leave imports out from the beginning of the file, so this sentence was little misleading. It's not perfect still, but at least now it's clear where imports are left out.