### PR TITLE
Asynkroninen kirjoitettu väärin

### DIFF
--- a/osa3.md
+++ b/osa3.md
@@ -43,9 +43,9 @@ permalink: /osa3/
 
 ## Muutama huomio
 
-### setState on asynkrooninen
+### setState on asynkroninen
 
-Muutamat ovat jo törmänneet siihen, että **React kutsuu funktiota setState asynkroonisesti**, eli jos meillä on seuraava koodi
+Muutamat ovat jo törmänneet siihen, että **React kutsuu funktiota setState asynkronisesti**, eli jos meillä on seuraava koodi
 
 ```js
 console.log(this.state.counter)

--- a/osa6.md
+++ b/osa6.md
@@ -1400,7 +1400,7 @@ export const initializeNotes = () => {
 }
 ```
 
-Sisemmässä funktiossaan, eli _asynkroonisessa actionissa_ operaatio hakee ensin palvelimelta kaikki muistiinpanot ja sen jälkeen _dispatchaa_ muistiinpanot storeen lisäävän actionin.
+Sisemmässä funktiossaan, eli _asynkronisessa actionissa_ operaatio hakee ensin palvelimelta kaikki muistiinpanot ja sen jälkeen _dispatchaa_ muistiinpanot storeen lisäävän actionin.
 
 Komponentti _App_ voidaan nyt määritellä seuraavasti:
 


### PR DESCRIPTION
Oikea kirjoitusasu on yhdellä o:lla, esim. http://www.sanakirja.org/search.php?id=315416&l2=17