### PR TITLE
Fix usage of non-existent property "new" on Date object

### DIFF
--- a/osa2.md
+++ b/osa2.md
@@ -745,7 +745,7 @@ addNote = (event) => {
   event.preventDefault()
   const noteObject = {
     content: this.state.newNote,
-    date: new Date().new,
+    date: new Date().toISOString(),
     important: Math.random() > 0.5,
     id: this.state.notes.length + 1
   }


### PR DESCRIPTION
Using the ".new" here results in notes date being set to undefined. toISOString method creates an ISO 8601 timestamp, which are used in the example notes provided in the material.

![image](https://user-images.githubusercontent.com/1039316/40344132-0c48fd92-5d9c-11e8-921f-8abb5e121c61.png)
