### PR TITLE
No instructions given to install axios

### DIFF
--- a/osa6.md
+++ b/osa6.md
@@ -1122,6 +1122,12 @@ const getAll = async () => {
 export default { getAll }
 ```
 
+Asennetaan myös axios projektiin
+
+```bash
+npm install axios --save
+```
+
 Muutetaan _nodeReducer_:issa tapahtuva muistiinpanojen tilan alustusta, siten että oletusarvoisesti mustiinpanoja ei ole:
 
 ```js

--- a/osa6.md
+++ b/osa6.md
@@ -639,7 +639,7 @@ const ConnectedNoteList = connect(
 export default ConnectedNoteList
 ```
 
-Nyt komponentti voi dispatchata suoraan action creatorin _importanceToggling_ määrittelemän actionin kutsumalla prosien kautta saamaansa funktiota koodissa:
+Nyt komponentti voi dispatchata suoraan action creatorin _importanceToggling_ määrittelemän actionin kutsumalla propsien kautta saamaansa funktiota koodissa:
 
 ```js
 class NoteList extends React.Component {


### PR DESCRIPTION
There was no mention on installing axios to the project and it is not included in the original dependencies given in the initial files for the examples (https://github.com/FullStack-HY/redux-notes/blob/part5-6/package.json). Trying to follow the examples will result in an error. Minor issue, but giving instructions when to install dependencies is the practice used with other parts of the Mooc.

Also fixes a typo.