### PR TITLE
Removes references to watch command

### DIFF
--- a/osa7.md
+++ b/osa7.md
@@ -512,7 +512,7 @@ Ratkaisun tarjoaa [webpack-dev-server](https://webpack.js.org/guides/development
 npm install --save-dev webpack-dev-server
 ```
 
-Määritellään dev-serverin käynnistävä npm-skripti (äsken lisätty skripti _watch_ on poistettu koska sille ei ole käyttöä):
+Määritellään dev-serverin käynnistävä npm-skripti:
 
 ```bash
 {

--- a/osa7.md
+++ b/osa7.md
@@ -535,7 +535,7 @@ const config = {
     filename: 'main.js'
   },
   devServer: {
-    contentBase: path.resolve(__dirname, "dist"),
+    contentBase: path.resolve(__dirname, 'dist'),
     compress: true,
     port: 3000
   },


### PR DESCRIPTION
The watch command is never defined so mention of it missing is useless.

Also changes double quotes to single quotes as these are used in other strings in webpack config example file.