### PR TITLE
jest version 23.4.2 fix SecurityError

### DIFF
--- a/osa4.md
+++ b/osa4.md
@@ -320,6 +320,22 @@ määritellään _npm_ skripti _test_ suorittamaan testaus jestillä ja raportoi
 }
 ```
 
+Jestin uudemmissa versioissa näyttäisi olevan tarve kertoa, että suoritusympäristönä on käytössä Node. Tämä tapahtuu esim. lisäämällä _package.json_ tiedoston loppuun:
+ ```js
+{
+  //...
+  "jest": {
+    "testEnvironment": "node"
+  }
+}
+```
+Tai vaihtoehtoisesti Jest löytää myös oletuksena asetustiedoston nimellä _jest.config.js_, jonne suoritusympäristön määrittely tapahtuu seuraavasti:
+ ```js
+module.exports = {
+    testEnvironment : "node"
+}
+```
+
 Tehdään testejä varten hakemisto _tests_ ja sinne tiedosto _palindrom.test.js_, jonka sisältö on seuraava
 
 ```js


### PR DESCRIPTION
Näyttäisi uudemmissa Jestin versioissa (v23.4.2) olevan tarve kertoa, että käytössä on Node. (Linux Ubuntu, node v 8.11.3)
Muutoin tulee seuraavanlaista virhettä:

 FAIL  tests/palindrom.test.js
  ● Test suite failed to run
    SecurityError: localStorage is not available for opaque origins
      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

Korjaus löydetty tuolta:
https://github.com/facebook/jest/issues/6766
Tilanne korjaantuu tuolla "testEnvironment" asetuksella, joko package.json tai default conf-tiedostossa jest.conf.js.
En tiedä onko molemmat vaihtoehdot tarpeelliset, jos käytäntö muuttuu jatkossa.