### PR TITLE
Update osa4.md

### DIFF
--- a/osa4.md
+++ b/osa4.md
@@ -1129,7 +1129,7 @@ test('note without content is not added ', async () => {
     important: true
   }
 
-  const initialNotes = await api
+  const responseBeforePost = await api
     .get('/api/notes')
 
   await api
@@ -1137,10 +1137,10 @@ test('note without content is not added ', async () => {
     .send(newNote)
     .expect(400)
 
-  const response = await api
+  const responseAfterPost = await api 
     .get('/api/notes')
+  expect(responseAfterPost.body.length).toBe(responseBeforePost.body.length);
 
-  expect(response.body.length).toBe(initialNotes.length)
 })
 ```
 


### PR DESCRIPTION
  //const initialNotes = await api   //initialNotes määritelty beforeAll, menee ehkä sekaisin testien kanssa
Voisi siis ehkä olla nk. responseBeforePost ja responseAfterPost, jos nimeämiskäytäntö on vaan oikein?

Testi bugaa mielestäni tässä: //  expect(response.body.length).toBe(initialNotes.length)
Comparing two different types of values. Expected undefined but received number.

Eli pitäisi olla siis initialNotes.body. mutta ehkä selkeämpi siis ehkä: expect(responseAfterPost.body.length).toBe(responseBeforePost.body.length);

Yleisesti ottain noiden .length kanssa on saanut muutenkin tapella, kun on yrittänyt etsiä sellaista kätevää sql ISNULL tyyppistä löytääkseen milloin joku on siis null :)